### PR TITLE
Make tournament links open in new tab.

### DIFF
--- a/priv/static/map.js
+++ b/priv/static/map.js
@@ -8,7 +8,7 @@ fetch("tournaments").then((resp) => {
     resp.json().then((parsed_tourneys) => {
         let tourney_markers = parsed_tourneys.map((tourney) => {
             let { lat, lng } = tourney["location"];
-            return L.marker().setLatLng([lat, lng]).bindPopup(`<a href=${tourney["url"]}>${tourney["name"]}</a>`);
+            return L.marker().setLatLng([lat, lng]).bindPopup(`<a href=${tourney["url"]} target="_blank">${tourney["name"]}</a>`);
         });
         L.layerGroup(tourney_markers).addTo(myMap);
     })


### PR DESCRIPTION
Issue #5 

All tournament links open in a new tab once selected.

If you want to read up on the solution: 
https://www.w3docs.com/snippets/html/open-hyperlink-in-a-new-window.html

Nothing fancy here 🙂