### PR TITLE
organized tag structure, added margins in css to keep previous styling

### DIFF
--- a/priv/static/css/main.css
+++ b/priv/static/css/main.css
@@ -63,6 +63,11 @@ ol {
   overflow-y: scroll;
 }
 
+.about-section,
+#about-footer {
+  margin-top: 1rem;
+}
+
 #map {
   flex-grow: 1;
   display: flex; /* Needed for the spinning loady thingy to be centered. */

--- a/priv/static/index.html
+++ b/priv/static/index.html
@@ -7,12 +7,12 @@
     <title>Tournamap</title>
     <link rel="icon" type="image/x-icon" href="icon-cropped.png" />
 
+    
+    <!-- Style Sheets -->
     <link rel="stylesheet" 
           href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
           integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
           crossorigin="" />
-
-    <!-- Style Sheets -->
     <link rel="stylesheet" href="./css/normalize.css"/>
     <link rel="stylesheet" href="./css/main.css"/>
 
@@ -30,51 +30,66 @@
     <nav>
       <ul>
         <li class="navbar"><a href="/index.html">tournamap.gg</a></li>
-        <li class="navbar" id="about-btn">About</li>
+        <li class="navbar" id="about-btn"><a href="#">About</a></li>
       </ul>
     </nav>
     <div id="main">
       <section id="about" hidden>
-        <h2>About this Site</h2>
-        <p>
-          Tournamap.gg is a site for visualizing the location of offline video game tournaments. (Only Smash Ultimate is
-          supported so far.) Each pin represents an upcoming tournament, click on it for details.
-        </p>
-        <h2>Why did I make this?</h2>
-        <p>
-          <s>I was bored idk</s>
-          "Any tournaments happening near _____?" is a very common question in my community (NorCal). Some crazy
-          individuals, in response, handmade and maintained a map showing where the locals are and when they happen. I
-          thought that was awesome, and decided to try to automate something similar.
-        </p>
-        <h2>Data Source(s)</h2>
-        <p>
-          Data is pulled from <a href="https://smash.gg/">smash.gg</a> roughly every half hour. We hope to eventually
-          support other sources, such as challonge.
-        </p>
-        <h2>If your tournament isn't listed</h2>
-        <ol>
-          <li>
-            Make sure your tournament listing is publicly visible and discoverable. Someone should be able to find the
-            page from the internet without being logged in.
-          </li>
-          <li>
-            If your tournament was recently published, try waiting an hour. The data is updated every half hour, but it
-            may take some time for the updated data to become visible.
-          </li>
-          <li>
-            If all else fails, email <a href="mailto:admin@tournamap.gg">admin@tournamap.gg </a> with a link to your
-            tournament so we can figure out why it isn't being shown.
-          </li>
-        </ol>
-        <h2>How to contribute</h2>
-        The source code for the project can be found <a href="https://github.com/perrycate/tournamap">on GitHub</a>. All
-        forms of contribution (code, comments, etc) are welcome!
-        <br />
-        <br />
-        I stream most Mondays, Wednesdays, and Fridays around 6:30 Pacific / 9:30 Eastern while working on the site.
-        <a href="https://twitch.tv/graviddd">Come watch and/or chat and/or help!</a>
+        <section id="about-site" class="about-section">
+          <h2>About this Site</h2>
+          <p>
+            Tournamap.gg is a site for visualizing the location of offline video game tournaments. (Only Smash Ultimate is
+            supported so far.) Each pin represents an upcoming tournament, click on it for details.
+          </p>
+        </section>
+        <section id="why" class="about-section">
+          <h2>Why did I make this?</h2>
+          <p>
+            <s>I was bored idk</s>
+            "Any tournaments happening near _____?" is a very common question in my community (NorCal). Some crazy
+            individuals, in response, handmade and maintained a map showing where the locals are and when they happen. I
+            thought that was awesome, and decided to try to automate something similar.
+          </p>
+        </section>
+        <section id="data-sources" class="about-section">
+          <h2>Data Source(s)</h2>
+          <p>
+            Data is pulled from <a href="https://smash.gg/">smash.gg</a> roughly every half hour. We hope to eventually
+            support other sources, such as challonge.
+          </p>
+        </section>
+        <section id="listing" class="about-section">
+          <h2>If your tournament isn't listed</h2>
+          <ol>
+            <li>
+              <p>
+                Make sure your tournament listing is publicly visible and discoverable. Someone should be able to find the page from the internet without being logged in.
+              </p>
+            </li>
+            <li>
+              <p>
+                If your tournament was recently published, try waiting an hour. The data is updated every half hour, but it may take some time for the updated data to become visible.
+              </p>
+            </li>
+            <li>
+              <p>
+                If all else fails, email <a href="mailto:admin@tournamap.gg">admin@tournamap.gg </a> with a link to your tournament so we can figure out why it isn't being shown.
+              </p>
+            </li>
+          </ol>
+        </section>
+        <section id="contribution" class="about-section">
+          <h2>How to contribute</h2>
+          <p>
+            The source code for the project can be found <a href="https://github.com/perrycate/tournamap">on GitHub</a>. All forms of contribution (code, comments, etc) are welcome!
+          </p>
+        </section>
         <!--TODO once we have a feedback form, mention it here. -->
+        <footer id="about-footer">
+          <p>
+            I stream most Mondays, Wednesdays, and Fridays around 6:30 Pacific / 9:30 Eastern while working on the site.<a href="https://twitch.tv/graviddd">Come watch and/or chat and/or help!</a>
+          </p>
+        </footer>
       </section>
       <section id="map">
         <a href="http://mapbox.com/about/maps" class="mapbox-logo" target="_blank">Mapbox</a>


### PR DESCRIPTION
In this change I attempted to organize the html file by cleaning up or adding tags to organize similar content. I also went ahead and removed the break line elements and opted to use css styling to achieve the same results. The reason I added the <a> tag for the about on line 33 was so that it was obviously it is a clickable link on hover (I think its safer to assume a user wont understand unless the visual is there). For future updates, it may be wise to reconsider some of the class and id names. Lastly, I moved the link element into the "<!-- Style Sheets -->" section in the head portion of the html. I'm not sure if you would like to keep this below the normalize.css link element. Please let me know if you have any thoughts or concerns. Thanks for reading