### PR TITLE
Add last updated indicator for tournament data

### DIFF
--- a/lib/util.ex
+++ b/lib/util.ex
@@ -51,6 +51,7 @@ defmodule Util do
       lng
       startAt
       endAt
+      updatedAt
       slug
     }
   }
@@ -84,6 +85,7 @@ defmodule Util do
         },
         "start_time" => sgg_data["startAt"],
         "end_time" => sgg_data["endAt"],
+        "updated_at" => sgg_data["updatedAt"],
         "url" => "https://start.gg/" <> (sgg_data["slug"])
       }
     end)


### PR DESCRIPTION
Reference issue: #36 
- Added in the `updatedAt` field to the graphql query that gets sent
- Pull that new field into the map of tournaments that gets generated under the name `updated_at` to keep with naming convention

I figure if we wanted to put this data anywhere, it could go in along with #32 but up to you!