### PR TITLE
Handle paginated data from start.gg properly

### DIFF
--- a/lib/util.ex
+++ b/lib/util.ex
@@ -19,20 +19,13 @@ defmodule Util do
     case System.get_env(@auth_env_var) do
       nil -> {:error, "No auth token specified. Make sure #{@auth_env_var} is set in the environment"}
       auth ->
-        # Rather than write code to figure out how many pages there are...
-        # let's just assume there are no more than 10 lol.
-        # (At time of writing there are less than 1,000 upcoming tournaments,
-        # which can easily fit in only 2 pages.)
-        tourneys =
-          1..10
-          |> Enum.map(&get_tourney_page(auth, &1))
-          |> List.flatten
+        tourneys = get_tourney_page([], auth, 1)
 
-          { :ok, %{ tournament_data: tourneys, metadata: %{ updated_at: DateTime.now!("Etc/UTC") |> DateTime.to_unix()}} }
+        { :ok, %{ tournament_data: tourneys, metadata: %{ updated_at: DateTime.now!("Etc/UTC") |> DateTime.to_unix()}} }
     end
   end
 
-  def get_tourney_page(auth, page_num) do
+  def get_tourney_page(tourney_list, auth, page_num) do
     body = %{
       "query" => "query AllUltimateTournaments($perPage: Int, $pageNum: Int) {
         tournaments(query: {
@@ -43,14 +36,16 @@ defmodule Util do
             upcoming: true
             hasOnlineEvents: false
           }
-        }) { pageInfo {
+        }) {
+          pageInfo {
             total
             totalPages
             page
             perPage
             sortBy
             filter
-          } nodes {
+          }
+          nodes {
             id
             name
             lat
@@ -75,24 +70,47 @@ defmodule Util do
 
     case HTTPoison.post("https://api.start.gg/gql/alpha", JSON.encode!(body), headers) do
       {:ok, resp} ->
-        resp.body
-        |> JSON.decode
-        |> format_decoded_response
+        tourney_data = resp.body
+                      |> JSON.decode()
+                      |> extract_data()
+
+        total_pages = tourney_data
+                      |> Map.get("pageInfo")
+                      |> Map.get("totalPages")
+
+        cond do
+          total_pages < 1 ->
+            IO.puts(:stderr, "No tournament pages found.")
+            System.stop(1)
+          page_num < total_pages ->
+            # There are more pages. Add the entries from this page to the
+            # tourney list and get the next page.
+            this_page = format_raw_data(tourney_data)
+            get_tourney_page(this_page ++ tourney_list, auth, page_num + 1)
+          page_num == total_pages ->
+            # This is the last page.
+            this_page = format_raw_data(tourney_data)
+            this_page ++ tourney_list
+        end
       {:error, reason} ->
         IO.puts(:stderr, reason)
         System.stop(1)
     end
   end
 
-  def format_decoded_response({:ok, decoded_map = %{"success" => false}}) do
+  def extract_data({:ok, decoded_map = %{"success" => false}}) do
     IO.puts(:stderr, Map.get(decoded_map, "message"))
     System.stop(1)
   end
 
-  def format_decoded_response({:ok, decoded_map}) do
+  def extract_data({:ok, decoded_map}) do
     decoded_map
     |> Map.get("data")
     |> Map.get("tournaments")
+  end
+
+  def format_raw_data(tourney_data) do
+    tourney_data
     |> Map.get("nodes")
     # Finesse data into our own non-start.gg format.
     |> Enum.map(fn sgg_data ->


### PR DESCRIPTION
PR for #58 

I considered two approaches for this:

1. First request sent reads total number of pages from PageInfo. This number can be used as the upper limit of the range for the Enum.map call. This means we send an extra request just to get the total pages.
2. To avoid the extra request, we can make get_tourney_page() a recursive function that adds entries from a page to an accumulative list and returns after the last page.

I went with approach 2, but I'm open to any other suggestions.